### PR TITLE
PDF 파일을 제대로 불러오지 못하는 이슈 해결

### DIFF
--- a/src/entities/pdf-file/api/get-pdf-file-url.test.ts
+++ b/src/entities/pdf-file/api/get-pdf-file-url.test.ts
@@ -1,0 +1,123 @@
+import { createOptionalPublicServerSupabaseClient } from '@/shared/lib/supabase/public-server';
+import { createOptionalServiceRoleSupabaseClient } from '@/shared/lib/supabase/service-role';
+
+import { getPdfFileUrl } from './get-pdf-file-url';
+
+vi.mock('@/shared/lib/supabase/public-server', () => ({
+  createOptionalPublicServerSupabaseClient: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/supabase/service-role', () => ({
+  createOptionalServiceRoleSupabaseClient: vi.fn(),
+}));
+
+type MockStorage = {
+  createSignedUrl: ReturnType<typeof vi.fn>;
+  getPublicUrl: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * Supabase storage mock 객체를 생성합니다.
+ */
+const createSupabaseMock = (storage: MockStorage) => ({
+  storage: {
+    from: vi.fn().mockReturnValue(storage),
+  },
+});
+
+describe('getPdfFileUrl', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('signed URL 조회 시 service role 클라이언트를 우선 사용한다', async () => {
+    const serviceStorage = {
+      createSignedUrl: vi.fn().mockResolvedValue({
+        data: {
+          signedUrl: 'https://example.com/signed-by-service.pdf',
+        },
+        error: null,
+      }),
+      getPublicUrl: vi.fn(),
+    };
+    const publicStorage = {
+      createSignedUrl: vi.fn(),
+      getPublicUrl: vi.fn(),
+    };
+
+    vi.mocked(createOptionalServiceRoleSupabaseClient).mockReturnValue(
+      createSupabaseMock(serviceStorage) as never,
+    );
+    vi.mocked(createOptionalPublicServerSupabaseClient).mockReturnValue(
+      createSupabaseMock(publicStorage) as never,
+    );
+
+    const result = await getPdfFileUrl({ kind: 'resume', accessType: 'signed' });
+
+    expect(result).toBe('https://example.com/signed-by-service.pdf');
+    expect(serviceStorage.createSignedUrl).toHaveBeenCalledTimes(1);
+    expect(publicStorage.createSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('service role이 없으면 public 서버 클라이언트로 signed URL을 조회한다', async () => {
+    const publicStorage = {
+      createSignedUrl: vi.fn().mockResolvedValue({
+        data: {
+          signedUrl: 'https://example.com/signed-by-public.pdf',
+        },
+        error: null,
+      }),
+      getPublicUrl: vi.fn(),
+    };
+
+    vi.mocked(createOptionalServiceRoleSupabaseClient).mockReturnValue(null);
+    vi.mocked(createOptionalPublicServerSupabaseClient).mockReturnValue(
+      createSupabaseMock(publicStorage) as never,
+    );
+
+    const result = await getPdfFileUrl({ kind: 'resume', accessType: 'signed' });
+
+    expect(result).toBe('https://example.com/signed-by-public.pdf');
+  });
+
+  it('storage object가 없으면 null을 반환한다', async () => {
+    const publicStorage = {
+      createSignedUrl: vi.fn().mockResolvedValue({
+        data: null,
+        error: {
+          message: 'Object not found',
+        },
+      }),
+      getPublicUrl: vi.fn(),
+    };
+
+    vi.mocked(createOptionalServiceRoleSupabaseClient).mockReturnValue(null);
+    vi.mocked(createOptionalPublicServerSupabaseClient).mockReturnValue(
+      createSupabaseMock(publicStorage) as never,
+    );
+
+    const result = await getPdfFileUrl({ kind: 'resume', accessType: 'signed' });
+
+    expect(result).toBeNull();
+  });
+
+  it('public accessType일 때 public URL을 반환한다', async () => {
+    const publicStorage = {
+      createSignedUrl: vi.fn(),
+      getPublicUrl: vi.fn().mockReturnValue({
+        data: {
+          publicUrl: 'https://example.com/public.pdf',
+        },
+      }),
+    };
+
+    vi.mocked(createOptionalServiceRoleSupabaseClient).mockReturnValue(null);
+    vi.mocked(createOptionalPublicServerSupabaseClient).mockReturnValue(
+      createSupabaseMock(publicStorage) as never,
+    );
+
+    const result = await getPdfFileUrl({ kind: 'resume', accessType: 'public' });
+
+    expect(result).toBe('https://example.com/public.pdf');
+  });
+});

--- a/src/entities/pdf-file/api/get-pdf-file-url.ts
+++ b/src/entities/pdf-file/api/get-pdf-file-url.ts
@@ -1,4 +1,5 @@
 import { createOptionalPublicServerSupabaseClient } from '@/shared/lib/supabase/public-server';
+import { createOptionalServiceRoleSupabaseClient } from '@/shared/lib/supabase/service-role';
 
 import 'server-only';
 
@@ -17,6 +18,14 @@ type GetPdfFileUrlOptions = {
 };
 
 const DEFAULT_SIGNED_URL_EXPIRES_IN_SECONDS = 60 * 10;
+
+/**
+ * signed URL 생성 시 사용할 Supabase 클라이언트를 선택합니다.
+ * - 1순위: service role (private bucket/RLS 우회)
+ * - 2순위: public anon
+ */
+const resolvePdfStorageClient = () =>
+  createOptionalServiceRoleSupabaseClient() ?? createOptionalPublicServerSupabaseClient();
 
 /**
  * Supabase Storage 객체가 존재하지 않는지 확인합니다.
@@ -39,7 +48,7 @@ export const getPdfFileUrl = async ({
   const resolvedBucket = bucket ?? storageConfig.bucket;
   const resolvedFilePath = filePath ?? storageConfig.filePath;
   const resolvedDownloadFileName = downloadFileName ?? storageConfig.downloadFileName;
-  const supabase = createOptionalPublicServerSupabaseClient();
+  const supabase = resolvePdfStorageClient();
   if (!supabase) return null;
 
   const storage = supabase.storage.from(resolvedBucket);


### PR DESCRIPTION
## 🚨 주요 고민 및 해결 과정

### 문제

- `anon` 키로 `createSignedUrl('pdf/ParkChaewon-Resume.pdf')` 호출 시 `Object not found (404)`가 발생했습니다.
- 같은 프로젝트에서 `service_role`로 확인하면 `pdf` 버킷은 `public: false`이고 파일 `ParkChaewon-Resume.pdf`가 실제로 존재했습니다.
- 즉 파일 없음이 아니라, 현재 코드가 private 버킷에 대해 `anon` 클라이언트로 signed URL을 만들려다 실패한 케이스입니다.

#### 왜 `pdf 준비 중`이 뜨는지
- [get-pdf-file-url.ts](/home/chaen/programming/chaen/src/entities/pdf-file/api/get-pdf-file-url.ts:1)에서 기존엔 `createOptionalPublicServerSupabaseClient`(anon)만 사용.
- signed URL 실패가 `Object not found`로 들어오면 `null` 반환.
- [get-resume-page-data.ts](/home/chaen/programming/chaen/src/views/resume/model/get-resume-page-data.ts:22)에서 `resumeUrl === null`이면 UI가 `download_unavailable_label`(`pdf 준비 중`)을 표시.

### 해결 과정

- [get-pdf-file-url.ts](/home/chaen/programming/chaen/src/entities/pdf-file/api/get-pdf-file-url.ts:22)
- signed URL 생성 클라이언트 선택을 `service role 우선 -> 없으면 public anon`으로 변경했습니다.

#### 테스트 추가
- [get-pdf-file-url.test.ts](/home/chaen/programming/chaen/src/entities/pdf-file/api/get-pdf-file-url.test.ts:1)
- 검증 케이스:
  - signed URL 시 service role 우선 사용
  - service role 없으면 public fallback
  - object missing 시 null
  - public accessType 시 publicUrl 반환

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * PDF 파일 URL 검색 기능에 대한 포괄적인 테스트 스위트 추가
  * 서명된 URL 및 공개 액세스 타입에 대한 검증 포함

* **개선 사항**
  * 클라이언트 선택 로직 개선으로 안정성 및 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->